### PR TITLE
relax numpy dep in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ tiktoken = ">=0.6.0"
 scikit-learn = "^1.2.0"
 boostedblob = "^0.15.3"
 blobfile = "^2.1.1"
-numpy = "^1.24.0"
+numpy = ">=1.24.0"
 orjson = "^3.10.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Since SAELens depends on `automated-interpretability`, any dependency constraints here also apply to SAELens. This means SAELens will downgrade numpy to old 1.x versions on install. It doesn't look like there is any issue with using numpy 2.x, either here or in SAELens, so this dep is likely just overly strict out of caution. This PR relaxes the numpy dep to allow new versions of numpy to work with automated-interpretability.