### PR TITLE
Relax versioning for httpx to allow for compatibility with `google-genai`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "automated-interpretability"
-version = "0.0.13"
+version = "0.0.14"
 description = "OpenAI and Neuronpedia's implementation of automated-interpretability, with some updates. Not officially affiliated with OpenAI."
 authors = ["OpenAI, Neuronpedia"]
 packages = [{ include = "neuron_explainer" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = [{ include = "neuron_explainer" }]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-httpx = "^0.27.0"
+httpx = ">=0.27.0, <1.0.0"
 tiktoken = ">=0.6.0"
 scikit-learn = "^1.2.0"
 boostedblob = "^0.15.3"


### PR DESCRIPTION
I'm currently working on a project that requires both this library (via `sae-lens`) and `google-genai` to be installed simultaneously. 

The package conflict is with the `httpx` dependency (`google-genai` requires `httpx>=0.28.1` and this library requires `httpx=^0.27.0`). I'd like to bump the version to remove the conflict.

I've tested this change using the [explain_puzzles.ipynb](https://github.com/openai/automated-interpretability/blob/main/neuron-explainer/demos/explain_puzzles.ipynb) demo colab and it doesn't seem to break any core functionality.